### PR TITLE
allow count property to be customized

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-module.exports = function (arr, label) {
+module.exports = function (arr, nameLabel, countLabel) {
   var counts = {}
-  label = label || 'value'
+  nameLabel = nameLabel || 'value'
+  countLabel = countLabel || 'count'
 
   arr.forEach(function (value) {
     if (typeof value !== 'string') return
@@ -10,8 +11,8 @@ module.exports = function (arr, label) {
   return Object.keys(counts)
     .map(function (key) {
       var obj = {}
-      obj[label] = key
-      obj.count = counts[key]
+      obj[nameLabel] = key
+      obj[countLabel] = counts[key]
       return obj
     })
     .sort(function (a, b) { return b.count - a.count })

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,19 @@ count(['apple', 'banana', 'apple'], 'fruit')
 // ]
 ```
 
+You can also override the name of the `count` property:
+
+```js
+const packages = ['express', 'lodash', 'express', 'lodash', 'express', 'banana']
+count(packages, 'package', 'dependents')
+
+// [
+//   {package: 'express', dependents: 3},
+//   {package: 'lodash', dependents: 2},
+//   {package: 'banana', dependents: 1}
+// ]
+```
+
 ## Tests
 
 ```sh

--- a/test.js
+++ b/test.js
@@ -16,7 +16,15 @@ test('countArrayValues', function (t) {
     {fruit: 'apple', count: 2},
     {fruit: 'banana', count: 1}
   ]
-  t.deepEqual(countArrayValues(input, 'fruit'), output, 'allows a custom property name to be set')
+  t.deepEqual(countArrayValues(input, 'fruit'), output, 'allows a custom property to be set for name')
+
+  input = ['express', 'lodash', 'express', 'lodash', 'express', 'banana']
+  output = [
+    {package: 'express', dependents: 3},
+    {package: 'lodash', dependents: 2},
+    {package: 'banana', dependents: 1}
+  ]
+  t.deepEqual(countArrayValues(input, 'package', 'dependents'), output, 'allows a custom property to be set for count')
 
   t.end()
 })


### PR DESCRIPTION
```js
const packages = ['express', 'lodash', 'express', 'lodash', 'express', 'banana']
count(packages, 'package', 'dependents')

// [
//   {package: 'express', dependents: 3},
//   {package: 'lodash', dependents: 2},
//   {package: 'banana', dependents: 1}
// ]
```
